### PR TITLE
Automate docker build with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ name: CI
 on:
   push:
     branches: [ master ]
+    # Run when container or environment is changed
+    paths:
+        - 'containers/*'
+        - 'environment.yml'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: containers/dockerfile_cpu
+          push: true
+          tags: cmelab/planckton_cpu:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Pushing 3gb images to docker hub is hard on my internet. This way we can automatically build and push the container.
See https://github.com/docker/build-push-action and https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths for more info
