### PR TITLE
Fix the way unyt quantities are serialized

### DIFF
--- a/environment-nohoomd.yml
+++ b/environment-nohoomd.yml
@@ -2,8 +2,9 @@ name: planckton
 channels:
   - conda-forge
 dependencies:
-  - ele=0.1.0
+  - ele=0.2.0
   - foyer=0.9.1
+  - gmso=0.6.0
   - gsd=2.4.2
   - mbuild=0.11.0
   - numpy=1.20

--- a/environment-nohoomd.yml
+++ b/environment-nohoomd.yml
@@ -1,27 +1,22 @@
 name: planckton
 channels:
   - conda-forge
-  - omnia #
 dependencies:
   - ele=0.1.0
-  - foyer=0.7.7
-  - gsd=2.2.0
-  - mdtraj=1.9.5 #
-  #- mbuild=0.10.12
-  - numpy=1.19
+  - foyer=0.9.1
+  - gsd=2.4.2
+  - mbuild=0.11.0
+  - numpy=1.20
   - openbabel=3.1.1
   - openmm>=7.5
-  - oset=0.1.3 #
-  - packmol=20 #
   - pip=20.2
   - pytest
   - pytest-cov
   - python=3.7
   - rdkit
-  - signac=1.6.0
-  - signac-flow=0.13.0
+  - signac=1.7.0
+  - signac-flow=0.14.0
   - unyt=2.8.0
   - pip:
-    - git+https://github.com/mosdef-hub/mbuild
     - git+https://github.com/rsdefever/antefoyer.git
-    - git+https://github.com/cmelab/planckton@v0.4.0
+    - git+https://github.com/cmelab/planckton@v0.4.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,28 +1,23 @@
 name: planckton
 channels:
   - conda-forge
-  - omnia #
 dependencies:
   - ele=0.1.0
-  - foyer=0.7.7
-  - gsd=2.2.0
-  - hoomd=2.9.3
-  - mdtraj=1.9.5 #
-  #- mbuild=0.10.12
-  - numpy=1.19
+  - foyer=0.9.1
+  - gsd=2.4.2
+  - hoomd=2.9.6
+  - mbuild=0.11.0
+  - numpy=1.20
   - openbabel=3.1.1
   - openmm>=7.5
-  - oset=0.1.3 #
-  - packmol=20 #
   - pip=20.2
   - pytest
   - pytest-cov
   - python=3.7
   - rdkit
-  - signac=1.6.0
-  - signac-flow=0.13.0
+  - signac=1.7.0
+  - signac-flow=0.14.0
   - unyt=2.8.0
   - pip:
-    - git+https://github.com/mosdef-hub/mbuild
     - git+https://github.com/rsdefever/antefoyer.git
-    - git+https://github.com/cmelab/planckton@v0.4.0
+    - git+https://github.com/cmelab/planckton@v0.4.1

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,9 @@ name: planckton
 channels:
   - conda-forge
 dependencies:
-  - ele=0.1.0
+  - ele=0.2.0
   - foyer=0.9.1
+  - gmso=0.6.0
   - gsd=2.4.2
   - hoomd=2.9.6
   - mbuild=0.11.0

--- a/planckton/__version__.py
+++ b/planckton/__version__.py
@@ -1,4 +1,4 @@
 """PlanckTon version."""
-VERSION = (0, 4, 0)
+VERSION = (0, 4, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/planckton/sim.py
+++ b/planckton/sim.py
@@ -218,9 +218,9 @@ class Simulation:
 
             try:
                 hoomd.run_upto(self.n_steps + 1, limit_multiple=self.gsd_write)
+                print("Simulation completed")
             except hoomd.WalltimeLimitReached:
                 print("Walltime limit reached")
-                pass
             finally:
                 gsd_restart.write_restart()
                 print("Restart file written")

--- a/planckton/tests/test_units.py
+++ b/planckton/tests/test_units.py
@@ -8,13 +8,13 @@ ref_distance = 0.35635948725613575 * u.nm
 
 
 def test_conversions():
-    quantity = 1 * u.gram
-    new_quantity = units.tuple_to_quantity(units.quantity_to_tuple(quantity))
+    quantity = 1 * u.gram / u.cm ** 3
+    new_quantity = units.string_to_quantity(units.quantity_to_string(quantity))
     assert quantity == new_quantity
 
-    tup = (1, "g")
-    new_tup = units.quantity_to_tuple(units.tuple_to_quantity(tup))
-    assert tup == new_tup
+    string = "1_g-cm**3"
+    new_string = units.quantity_to_string(units.string_to_quantity(string))
+    assert string == new_string
 
 
 def test_temperature_reduction():

--- a/planckton/tests/test_units.py
+++ b/planckton/tests/test_units.py
@@ -12,7 +12,7 @@ def test_conversions():
     new_quantity = units.string_to_quantity(units.quantity_to_string(quantity))
     assert quantity == new_quantity
 
-    string = "1_g-cm**3"
+    string = "1.0_g-cm**3"
     new_string = units.quantity_to_string(units.string_to_quantity(string))
     assert string == new_string
 

--- a/planckton/utils/units.py
+++ b/planckton/utils/units.py
@@ -13,11 +13,13 @@ constants = {
 }
 
 
-def quantity_to_tuple(quantity):
-    """Break a unyt.quantity into a tuple.
+def quantity_to_string(quantity):
+    """Break a unyt.quantity into a string.
 
-    Convert a unyt.quantity into a tuple containing its value and units in
-    string format. Useful for serialization.
+    Convert a unyt.quantity into a string containing its value and units in
+    string format separated by "_". Useful for serialization. Division symbols,
+    "/", which interfere with signac's workspace directory structure will be
+    replaced with a dash, "-".
 
     IMPORTANT: This function expects one quantity, not an array.
 
@@ -27,27 +29,29 @@ def quantity_to_tuple(quantity):
 
     Returns
     -------
-    (number, string)
+    str :
+        unyt quantity in form "number_unit"
     """
-    return (quantity.item(), str(quantity.units))
+    return f"{quantity.item()}_{str(quantity.units).replace('/','-')}"
 
 
-def tuple_to_quantity(tup):
-    """Convert tuple to unyt.quantity.
+def string_to_quantity(string):
+    """Convert a string to unyt.quantity.
 
-    Convert a tuple containing values and units in string format into a unyt
-    quantity.
+    Convert a string of  values and units separated by an underscore, "_", into
+    a unyt quantity. See also `quantity_to_string`.
 
     Parameters
     ----------
-    tup: tuple
-        first value is a number and the second value is a string with the units
+    string : str
+        Unyt quantity formatted as string, e.g., "number_units"
 
     Returns
     -------
     unyt.unyt_quantity
     """
-    return tup[0] * u.Unit(tup[1])
+    num, unit = string.split("_")
+    return float(num) * u.Unit(unit.replace("-", "/"))
 
 
 def reduced_from_kelvin(T_SI, ref_energy):


### PR DESCRIPTION
unyt quantities (used in planckton for the density) were previously stored as tuples of (number, string) so that they were serializable and could be handled by signac. This tuple structure--combined with the "/" character in the units--made the signac directory structure really funky.

This PR fixes the way that unyt quantities are handled.

fixes #55 