### PR TITLE
Fix rescale velocities

### DIFF
--- a/planckton/sim.py
+++ b/planckton/sim.py
@@ -249,8 +249,6 @@ class Simulation:
             # Begin temp ramp
             for kT, tau, n_steps in zip(self.kT, self.tau, self.n_steps):
                 integrator.set_params(kT=kT, tau=tau)
-                # Reset velocities
-                integrator.randomize_velocities(seed=42)
 
                 try:
                     hoomd.run_upto(n_steps + 1, limit_multiple=self.gsd_write)


### PR DESCRIPTION
I found that I was getting particle out of box errors when the temperature changed in the ramp. I think this is in part due to the randomize velocities call, which makes sense when velocities are zero, but otherwise could be a bad idea.

@erjank and I discussed using [hoomd.md.update.rescale_temp](https://hoomd-blue.readthedocs.io/en/stable/module-md-update.html#hoomd.md.update.rescale_temp), but this method does not work on GPU, so I am leaving it out.

I will run some tests on Fry before merging. If this does not work, I will implement a short temperature ramp between changes. e.g., 
```
integrate.nvt(
    group = all, tau = 0.5, kT = variant.linear_interp([(0, 1.0), (1e5, 2.0)])
)
```